### PR TITLE
Use 0.13.0 instead of 0.13.0-RC3

### DIFF
--- a/src/main/scala/sbt/CrossBuilding.scala
+++ b/src/main/scala/sbt/CrossBuilding.scala
@@ -73,7 +73,7 @@ object CrossBuilding {
   }
   def currentCompatibleSbtVersion(version: String): String = version match {
     case "0.12" => "0.12.4"
-    case "0.13" => "0.13.0-RC3"
+    case "0.13" => "0.13.0"
     case _ => version
   }
   def chooseDefaultSbtVersion(version: String): String =


### PR DESCRIPTION
When using this plugin, having to download 0.13.0-RC3 instead of reusing 0.13.0 seems rather annoying. This pull request fixes this.
