### PR TITLE
General update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,20 @@ libraryDependencies <+= CrossBuilding.sbtModuleDependencyInit("scripted-plugin")
 crossBuildingSettings
 
 CrossBuilding.latestCompatibleVersionMapper ~= { mapper => version => version match {
-    case "0.13" => "0.13.2"
+    case "0.13" => "0.13.9"
     case x => mapper(x)
+  }
+}
+
+// Replace hard coded reference to defunct typesafe artifactory repository
+libraryDependencies ~= { oldDeps =>
+  oldDeps.map {
+    case sbtLaunch if sbtLaunch.name == "sbt-launch" =>
+      sbtLaunch.copy(explicitArtifacts = sbtLaunch.explicitArtifacts.map { artifact =>
+        artifact.copy(url = artifact.url.map { theUrl =>
+          url(theUrl.toString.replace("http://typesafe.artifactoryonline.com", "https://dl.bintray.com"))
+        })
+      })
+    case other => other
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.9

--- a/project/gpg.sbt
+++ b/project/gpg.sbt
@@ -1,3 +1,1 @@
-resolvers += Resolver.url("scalasbt", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
-addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,3 @@
-addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.2")
-
-resolvers ++= Seq(
-  Resolver.url("Typesafe repository", url("http://typesafe.artifactoryonline.com/typesafe/ivy-releases/"))(Resolver.defaultIvyPatterns),
-  "coda hale's repo" at "http://repo.codahale.com"
-)
+addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 
 addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.8.1")

--- a/src/main/scala/sbt/CrossBuilding.scala
+++ b/src/main/scala/sbt/CrossBuilding.scala
@@ -68,7 +68,7 @@ object CrossBuilding {
     byMajorVersion(version) {
       case 11 => "2.9.1"
       case 12 => "2.9.2"
-      case x if x >= 13 => "2.10.2"
+      case x if x >= 13 => "2.10.5"
     }
   def usesCrossBuilding(version: String): Boolean =
     byMajorVersion(version)(_ < 12)
@@ -79,7 +79,7 @@ object CrossBuilding {
   }
   def currentCompatibleSbtVersion(version: String): String = version match {
     case "0.12" => "0.12.4"
-    case "0.13" => "0.13.2"
+    case "0.13" => "0.13.11"
     case _ => version
   }
   def chooseDefaultSbtVersion(version: String): String =

--- a/src/main/scala/sbt/SbtScriptedSupport.scala
+++ b/src/main/scala/sbt/SbtScriptedSupport.scala
@@ -40,20 +40,20 @@ object SbtScriptedSupport {
   }
 
   def sbtLaunchUrl(version: String) =
-    "http://typesafe.artifactoryonline.com/typesafe/ivy-releases/%s/sbt-launch/%s/sbt-launch.jar" format (groupIdByVersion(version), version)
+    "https://dl.bintray.com/typesafe/ivy-releases/%s/sbt-launch/%s/sbt-launch.jar" format (groupIdByVersion(version), version)
 
   val scriptedSettings = seq(
     ivyConfigurations += scriptedConf,
     scriptedSbt <<= pluginSbtVersion(CrossBuilding.currentCompatibleSbtVersion),
-    scalaVersion in scripted := "2.10.2", // TODO: infer from resolved module
-    scriptedRunnerModule := "org.scala-sbt" % "scripted-sbt" % "0.13.0-RC3" % scriptedConf.toString,
+    scalaVersion in scripted := "2.10.5", // TODO: infer from resolved module
+    scriptedRunnerModule := "org.scala-sbt" % "scripted-sbt" % "0.13.11" % scriptedConf.toString,
     libraryDependencies <++= (scriptedSbt, scriptedRunnerModule) { (version, scriptedRunnerModule) =>
       Seq(
         scriptedRunnerModule,
         groupIdByVersion(version) % "sbt-launch" % version % scriptedConf.toString from sbtLaunchUrl(version)
       )
     },
-    resolvers += Resolver.url("Typesafe repository", url("http://typesafe.artifactoryonline.com/typesafe/ivy-releases/"))(Resolver.defaultIvyPatterns),
+    resolvers += Resolver.url("Typesafe repository", url("https://dl.bintray.com/typesafe/ivy-releases/"))(Resolver.defaultIvyPatterns),
     sbtTestDirectory <<= sourceDirectory / "sbt-test",
     scriptedBufferLog := true,
     scriptedClasspath <<= (classpathTypes, update) map { (ct, report) => PathFinder(Classpaths.managedJars(scriptedConf, ct, report).map(_.data)) },


### PR DESCRIPTION
- Upgraded to sbt 0.13.9 (0.13.11 has a binary incompatibility with the existing publish sbt-cross-building plugin, so we can't upgrade to that until a new sbt-cross-building plugin is released that fixes it).
- Upgraded all sbt plugins to latest versions.
- Fix binary incompatibility with sbt 0.13.11 (reflection is now used to invoke the changing method, I ran the scripted tests against both 0.13.9 and 0.13.11 to test that this works for both versions of the method).
- Update hard coded now defunct repositories to new bintray repos.
- Update latest sbt 0.13 and scala versions.
