### PR TITLE
Added support for cross building against sbt 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,20 @@ libraryDependencies <+= CrossBuilding.sbtModuleDependencyInit("scripted-plugin")
 crossBuildingSettings
 
 CrossBuilding.latestCompatibleVersionMapper ~= { mapper => version => version match {
-    case "0.13" => "0.13.2"
+    case "0.13" => "0.13.9"
     case x => mapper(x)
+  }
+}
+
+// Replace hard coded reference to defunct typesafe artifactory repository
+libraryDependencies ~= { oldDeps =>
+  oldDeps.map {
+    case sbtLaunch if sbtLaunch.name == "sbt-launch" =>
+      sbtLaunch.copy(explicitArtifacts = sbtLaunch.explicitArtifacts.map { artifact =>
+        artifact.copy(url = artifact.url.map { theUrl =>
+          url(theUrl.toString.replace("http://typesafe.artifactoryonline.com", "https://dl.bintray.com"))
+        })
+      })
+    case other => other
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.9

--- a/project/gpg.sbt
+++ b/project/gpg.sbt
@@ -1,3 +1,1 @@
-resolvers += Resolver.url("scalasbt", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
-addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,3 @@
-addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.2")
-
-resolvers ++= Seq(
-  Resolver.url("Typesafe repository", url("http://typesafe.artifactoryonline.com/typesafe/ivy-releases/"))(Resolver.defaultIvyPatterns),
-  "coda hale's repo" at "http://repo.codahale.com"
-)
+addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 
 addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.8.1")

--- a/src/main/scala/sbt/CrossBuilding.scala
+++ b/src/main/scala/sbt/CrossBuilding.scala
@@ -68,7 +68,7 @@ object CrossBuilding {
     byMajorVersion(version) {
       case 11 => "2.9.1"
       case 12 => "2.9.2"
-      case x if x >= 13 => "2.10.2"
+      case x if x >= 13 => "2.10.5"
     }
   def usesCrossBuilding(version: String): Boolean =
     byMajorVersion(version)(_ < 12)
@@ -79,7 +79,7 @@ object CrossBuilding {
   }
   def currentCompatibleSbtVersion(version: String): String = version match {
     case "0.12" => "0.12.4"
-    case "0.13" => "0.13.2"
+    case "0.13" => "0.13.11"
     case _ => version
   }
   def chooseDefaultSbtVersion(version: String): String =

--- a/src/main/scala/sbt/SbtPluginCross.scala
+++ b/src/main/scala/sbt/SbtPluginCross.scala
@@ -31,10 +31,10 @@ object SbtPluginCross
 		val x = Project.extract(state)
 	  import x._
     version match {
-      case v@CrossBuilding.Version(major, minor, null) if (minor ne null) && major.toInt >= 12 =>
+      case v@CrossBuilding.Version(epoch, major, minor, null) if (minor ne null) && (epoch.toInt > 0 | major.toInt >= 12) =>
          println(
            "WARNING: Setting version to '%s' is probably not what you intended. For " +
-           "binary-compatible building against sbt 0.%s.x please use version '0.%s'" format (v, major, major))
+           "binary-compatible building against sbt %s.%s.x please use version '%s.%s'" format (v, epoch, major, epoch, major))
       case _ =>
     }
 

--- a/src/main/scala/sbt/SbtScriptedSupport.scala
+++ b/src/main/scala/sbt/SbtScriptedSupport.scala
@@ -40,20 +40,20 @@ object SbtScriptedSupport {
   }
 
   def sbtLaunchUrl(version: String) =
-    "http://typesafe.artifactoryonline.com/typesafe/ivy-releases/%s/sbt-launch/%s/sbt-launch.jar" format (groupIdByVersion(version), version)
+    "https://dl.bintray.com/typesafe/ivy-releases/%s/sbt-launch/%s/sbt-launch.jar" format (groupIdByVersion(version), version)
 
   val scriptedSettings = seq(
     ivyConfigurations += scriptedConf,
     scriptedSbt <<= pluginSbtVersion(CrossBuilding.currentCompatibleSbtVersion),
-    scalaVersion in scripted := "2.10.2", // TODO: infer from resolved module
-    scriptedRunnerModule := "org.scala-sbt" % "scripted-sbt" % "0.13.0-RC3" % scriptedConf.toString,
+    scalaVersion in scripted := "2.10.5", // TODO: infer from resolved module
+    scriptedRunnerModule := "org.scala-sbt" % "scripted-sbt" % "0.13.11" % scriptedConf.toString,
     libraryDependencies <++= (scriptedSbt, scriptedRunnerModule) { (version, scriptedRunnerModule) =>
       Seq(
         scriptedRunnerModule,
         groupIdByVersion(version) % "sbt-launch" % version % scriptedConf.toString from sbtLaunchUrl(version)
       )
     },
-    resolvers += Resolver.url("Typesafe repository", url("http://typesafe.artifactoryonline.com/typesafe/ivy-releases/"))(Resolver.defaultIvyPatterns),
+    resolvers += Resolver.url("Typesafe repository", url("https://dl.bintray.com/typesafe/ivy-releases/"))(Resolver.defaultIvyPatterns),
     sbtTestDirectory <<= sourceDirectory / "sbt-test",
     scriptedBufferLog := true,
     scriptedClasspath <<= (classpathTypes, update) map { (ct, report) => PathFinder(Classpaths.managedJars(scriptedConf, ct, report).map(_.data)) },

--- a/src/test/scala/sbt/TestCrossBuilding.scala
+++ b/src/test/scala/sbt/TestCrossBuilding.scala
@@ -27,5 +27,8 @@ class TestCrossBuilding extends Specification {
     "0.13.0" in {
       CrossBuilding.groupIdByVersion("0.13.0") must be_==(ScalaSbt)
     }
+    "1.0" in {
+      CrossBuilding.groupIdByVersion("1.0.0") must be_==(ScalaSbt)
+    }
   }
 }


### PR DESCRIPTION
Depends on #34 being merged first.

I don't know if this actually works, since the scripted tests can't run against 1.0 yet because the published version of sbt-cross-building that sbt-cross-building depends on doesn't support cross building against 1.0.

Also, since sbt 1.0 only supports auto plugins, a new set of scripted tests that uses auto plugins will need to be created before this can be tested, and that probably means we have to drop support for non auto plugins sbt versions.

See #33 for a general discussion on the path to 1.0 support.
